### PR TITLE
Rainbow is replaced with terminal-colors

### DIFF
--- a/lib/log.rb
+++ b/lib/log.rb
@@ -1,6 +1,6 @@
 require 'English'
 
-require 'rainbow'; Rainbow.enabled = true
+require 'terminal_colors'
 
 require 'initializer'; Initializer.activate
 require 'dependency'; Dependency.activate

--- a/lib/log/defaults.rb
+++ b/lib/log/defaults.rb
@@ -57,11 +57,11 @@ module Log::Defaults
 
   def self.level_formatters
     {
-      error: proc { |message| Rainbow(message).bright.white.bg(:red) },
-      fatal: proc { |message| Rainbow(message).red.bg(:black) },
-      warn: proc { |message| Rainbow(message).yellow.bg(:black) },
-      debug: proc { |message| Rainbow(message).green },
-      trace: proc { |message| Rainbow(message).cyan }
+      error: proc { |message| TerminalColors::Apply.(message, bg: :red, bold: true) },
+      fatal: proc { |message| TerminalColors::Apply.(message, fg: :red, bg: :black) },
+      warn: proc { |message| TerminalColors::Apply.(message, fg: :yellow, bg: :black) },
+      debug: proc { |message| TerminalColors::Apply.(message, fg: :green) },
+      trace: proc { |message| TerminalColors::Apply.(message, fg: :cyan) }
     }
   end
 end

--- a/lib/log/format/color.rb
+++ b/lib/log/format/color.rb
@@ -1,5 +1,5 @@
 module Log::Format::Color
   def self.header(text)
-    Rainbow(text).white
+    TerminalColors::Apply.(text, fg: :white)
   end
 end

--- a/log.gemspec
+++ b/log.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'evt-telemetry'
   s.add_runtime_dependency 'evt-clock'
 
-  s.add_runtime_dependency 'rainbow'
+  s.add_runtime_dependency 'terminal_colors'
 
   s.add_development_dependency 'test_bench'
 end


### PR DESCRIPTION
See https://github.com/ntl/terminal-colors

Following the rubygems fiasco with rainbow, I went ahead and coded up a potential replacement library. It doesn't depend on any native extensions :)