### PR TITLE
Allow excluding tags if logger is set to log _all

### DIFF
--- a/lib/log/filter.rb
+++ b/lib/log/filter.rb
@@ -27,7 +27,7 @@ class Log
         return true
       end
 
-      if log_all_tags?
+      if log_all_tags? && !tags_exluded_intersect?(message_tags)
         return true
       end
 
@@ -52,8 +52,12 @@ class Log
       logger_tag?(:_untagged)
     end
 
+    def tags_exluded_intersect?(message_tags)
+      return !(message_tags & logger_excluded_tags).empty?
+    end
+
     def tags_intersect?(message_tags)
-      if !(message_tags & logger_excluded_tags).empty?
+      if tags_exluded_intersect?(message_tags)
         return false
       end
 

--- a/test/automated/filter/tag/all_and_exclusion.rb
+++ b/test/automated/filter/tag/all_and_exclusion.rb
@@ -1,0 +1,26 @@
+require_relative '../../automated_init'
+
+context "Log" do
+  context "Filter" do
+    context "Tag" do
+      context "All and Exclusion" do
+        context "Messages with excluded tags" do
+          logger = Log::Controls::Log.example
+          logger.tags = [:_all, :'-some_other_tag']
+
+          sink = logger.telemetry_sink
+
+          logger.('some other message', tags: [:some_other_tag])
+
+          logged = sink.recorded_logged? do |record|
+            record.data.tags.include? :some_other_tag
+          end
+
+          test "Are not logged" do
+            refute(logged)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows excluding some noisy tags even if logger is set to log `_all` tags:

```sh
LOG_TAGS=_all,-get bin/start
```


Fixes #8 